### PR TITLE
Fix CI, unpin some reqs, pin docs, enable doc lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
                     python: 3.8
                     use_slepc: false
         env:
+            # for macOS only, make sure to pin this in tox.ini as well
             PC_VERSION: 3.13.5  # PETSc version
             SC_VERSION: 3.13.2  # SLEPc version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
                 key: precommit-${{ env.pythonLocation }}-${{ hashFiles('.pre-commit-config.yaml') }}
                 restore-keys: |
                     precommit-${{ env.pythonLocation }}-
-                    precommit-
 
         -   name: Install dependencies
             run: |
@@ -55,11 +54,7 @@ jobs:
 
         -   name: Linting
             run: |
-                tox -e lint,readme
-        -   name: Documentation check
-            run: |
-                echo "Uncomment me below once the badges are working..."
-            # tox -e check-docs
+                tox -e lint,check-docs,readme
 
     test:
         needs: init
@@ -67,21 +62,21 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false
-            max-parallel: 4
+            max-parallel: 5
             matrix:
-                python: [3.8]
+                python: [3.7, 3.9]
                 os: [ubuntu-latest]
-                use_slepc: [true]
+                use_slepc: [false]
                 include:
                 -   os: ubuntu-latest
-                    python: 3.7
-                    use_slepc: false
-                -   os: macos-latest
                     python: 3.8
-                    use_slepc: false
+                    use_slepc: true
                 -   os: macos-latest
                     python: 3.7
                     use_slepc: true
+                -   os: macos-latest
+                    python: 3.8
+                    use_slepc: false
         env:
             PC_VERSION: 3.13.5  # PETSc version
             SC_VERSION: 3.13.2  # SLEPc version
@@ -122,7 +117,6 @@ jobs:
             run: |
                 python -m pip install --upgrade pip
                 pip install tox tox-gh-actions codecov
-
 
         -   name: Restore PETSc/SLEPc tox cache
             if: matrix.use_slepc == true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
 
         -   name: Install dependencies
             run: |
+                sudo apt install pandoc
                 python -m pip install --upgrade pip
                 pip install tox
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: v0.790
     hooks:
     -   id: mypy
-        additional_dependencies: [numpy>=1.2.0, scipy>=1.6.0]
+        additional_dependencies: [numpy==1.20.0, scipy>=1.6.0]
 -   repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,4 +21,4 @@ help:
 
 clean: Makefile
 	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-	rm -rf source/api/
+	@rm -rf $(SOURCEDIR)/api/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 -r ../requirements.txt
-nbsphinx>=0.7
-sphinx>=3.3.0
+nbsphinx>=0.8
+sphinx==4.0.2  # https://github.com/spatialaudio/nbsphinx/issues/584
 sphinx-autodoc-annotation
 sphinx-autodoc-typehints>=1.10.3
 sphinx-copybutton

--- a/docs/source/acknowledgments.rst
+++ b/docs/source/acknowledgments.rst
@@ -12,7 +12,7 @@ and A. Sikorski for supplying us with an `code example`_ and guidance how to int
 The development of *pyGPCCA* started - based on the original `GPCCA`_ program written in MATLAB - at the beginning of
 2020 in a fork of `MSMTools`_, since it was planned to integrate GPCCA into MSMTools at this time.
 Due to this, some similarities in structure and code (indicated were evident) can be found.
-Futher the utility functions found in `pygpcca/utils/_utils.py`_ originate from MSMTools.
+Further utility functions found in `pygpcca/utils/_utils.py`_ originate from MSMTools.
 
 .. _`Marcus Weber`: https://www.zib.de/members/weber
 .. _`CMD`: https://www.zib.de/numeric/cmd
@@ -23,7 +23,7 @@ Futher the utility functions found in `pygpcca/utils/_utils.py`_ originate from 
 .. _`Python code`: https://gist.github.com/fabian-paul/14679b43ed27aa25fdb8a2e8f021bad5
 .. _`Alexander Sikorski`: https://www.zib.de/members/sikorski
 .. _`SLEPc`: https://slepc.upv.es/
-.. _`code example`: https://github.com/zib-cmd/cmdtools/blob/1c6b6d8e1c35bb487fcf247c5c1c622b4b665b0a/src/cmdtools/analysis/pcca.py#L64
+.. _`code example`: https://github.com/zib-cmd/cmdtools/blob/1c6b6d8e1c35bb487fcf247c5c1c622b4b665b0a/src/cmdtools/analysis/pcca.py#L64-L89
 .. _`GPCCA`: https://github.com/msmdev/gpcca
 .. _`MSMTools`: https://github.com/markovmodel/msmtools
 .. _`pygpcca/utils/_utils.py`: https://github.com/msmdev/pyGPCCA/blob/main/pygpcca/utils/_utils.py

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,7 +81,7 @@ napoleon_numpy_docstring = True
 napoleon_include_init_with_doc = False
 napoleon_use_rtype = True
 napoleon_use_param = True
-napoleon_custom_sections = [("Params", "Parameters")]
+napoleon_custom_sections = [("Params", "Parameters"), ("Credits", "References")]
 napoleon_use_admonition_for_examples = False
 napoleon_use_admonition_for_notes = False
 napoleon_use_admonition_for_references = False
@@ -112,6 +112,9 @@ spelling_add_pypi_package_names = True
 spelling_show_suggestions = True
 # see: https://pyenchant.github.io/pyenchant/api/enchant.tokenize.html
 spelling_filters = ["enchant.tokenize.URLFilter", "enchant.tokenize.EmailFilter"]
+
+# linkcheck
+linkcheck_anchors = False  # problem with specifying lines on GitHub in `acknowledgments.rst`
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -23,7 +23,7 @@ Version 1.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 .. rubric:: General
 
-- Minor improvements/fixes in README and acknowledgements.
+- Minor improvements/fixes in README and acknowledgments.
 
 1.0.0 :small:`2021-01-29`
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -25,3 +25,4 @@ Fackeldey
 Röblitz
 Sikorski
 Zuse
+mypy

--- a/pygpcca/_sorted_schur.py
+++ b/pygpcca/_sorted_schur.py
@@ -111,7 +111,8 @@ def _check_conj_split(eigenvalues: np.ndarray) -> bool:
 
 @d.dedent
 def _check_schur(P: np.ndarray, Q: np.ndarray, R: np.ndarray, eigenvalues: np.ndarray, method: str) -> None:
-    """Run a number of checks on the sorted Schur decomposition.
+    """
+    Run a number of checks on the sorted Schur decomposition.
 
     Parameters
     ----------
@@ -259,6 +260,11 @@ def sorted_krylov_schur(
     # We take the sequence of 1-D arrays and stack them as columns to make a single 2-D array.
     Q = np.column_stack([x.array for x in E.getInvariantSubspace()])
 
+    try:
+        # otherwise, R would be of shape `(k + 1, k)`
+        E.getDS().setExtraRow(False)
+    except AttributeError:
+        pass
     # Get the schur form
     R = E.getDS().getMat(SLEPc.DS.MatType.A)
     R.view()

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,11 @@ setup(
     extras_require=dict(
         # https://gitlab.com/petsc/petsc/-/issues/803
         slepc=[
-            "mpi4py>=3.0.3,<3.1",
-            "petsc>=3.13,<3.14",
-            "slepc>=3.13,<3.14",
-            "petsc4py>=3.13,<3.14",
-            "slepc4py>=3.13,<3.14",
+            "mpi4py>=3.0.3",
+            "petsc>=3.13,!=3.14",
+            "slepc>=3.13,!=3.14",
+            "petsc4py>=3.13,!=3.14",
+            "slepc4py>=3.13,!=3.14",
         ],
         dev=["pre-commit>=2.9.0", "bump2version>=1.0.2"],
         test=["tox>=3.20.1"],

--- a/tox.ini
+++ b/tox.ini
@@ -109,9 +109,9 @@ deps =
     pytest-cov
     pytest-mock
     # we manually install PETSc and SLEPc on the CI from source and the [dev] installation causes problems
-    macos-slepc: mpi4py>=3.0.3
-    macos-slepc: petsc4py>=3.13,!=3.14
-    macos-slepc: slepc4py>=3.13,!=3.14
+    macos-slepc: mpi4py>=3.0.3,<3.1
+    macos-slepc: petsc4py>=3.13,<3.14
+    macos-slepc: slepc4py>=3.13,<3.14
 extras =
     linux-slepc: slepc
 passenv = TOXENV CI CODECOV_* GITHUB_ACTIONS PETSC_* SLEPC_*

--- a/tox.ini
+++ b/tox.ini
@@ -109,14 +109,14 @@ deps =
     pytest-cov
     pytest-mock
     # we manually install PETSc and SLEPc on the CI from source and the [dev] installation causes problems
-    macos-slepc: mpi4py>=3.0.3,<3.1
-    macos-slepc: petsc4py>=3.13,<3.14
-    macos-slepc: slepc4py>=3.13,<3.14
+    macos-slepc: mpi4py>=3.0.3
+    macos-slepc: petsc4py>=3.13,!=3.14
+    macos-slepc: slepc4py>=3.13,!=3.14
 extras =
     linux-slepc: slepc
 passenv = TOXENV CI CODECOV_* GITHUB_ACTIONS PETSC_* SLEPC_*
 usedevelop = true
-commands = pytest --cov --cov-append --cov-report=term-missing --cov-config={toxinidir}/tox.ini --ignore docs/ {posargs:-vv}
+commands = python -m pytest --cov --cov-append --cov-report=term-missing --cov-config={toxinidir}/tox.ini --ignore docs/ {posargs:-vv}
 
 [testenv:covclean]
 description = Clean coverage files.
@@ -178,5 +178,6 @@ description = Check if README renders on PyPI.
 basepython = python3.8
 deps = twine >= 1.12.1
 skip_install = true
-commands = pip wheel -q -w {envtmpdir}/build --no-deps .
-           twine check {envtmpdir}/build/*
+commands =
+    pip wheel -q -w {envtmpdir}/build --no-deps .
+    twine check {envtmpdir}/build/*


### PR DESCRIPTION
I've unpinned PETSc/SLEPc upper bound requirements, pinned `sphinx` (bug with `nbsphinx`), add Python 3.9 testing and fix some warnings in docs (+ add docs linting).
The problem with a new `SLEPc` version was that getting the matrix included extra row, see [here](https://slepc.upv.es/slepc4py-current/docs/apiref/slepc4py.SLEPc.DS-class.html#setExtraRow), the solution here should be backwards compatible.