### PR TITLE
Pin jinja2 to 3.0.3 since 3.1.0 is buggy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 docrep>=0.3.1
+# pin jinja2 to fix "module 'jinja2.utils' has no attribute 'escape'" error during linting
+jinja2==3.0.3
 # https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule
 numpy>=1.17.0
 # https://github.com/scipy/scipy/releases/tag/v1.5.0


### PR DESCRIPTION
Fixing "module 'jinja2.utils' has no attribute 'escape'" error.