### PR TITLE
Fix linting problems with black (by pinning click) and flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: 20.8b1
     hooks:
     -   id: black
-        additional_dependencies: [toml]
+        additional_dependencies: ['click==8.0.1', toml]
 -   repo: https://github.com/timothycrosley/isort
     rev: 5.7.0
     hooks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-# pin click to fix "ImportError: cannot import name '_unicodefun' from 'click'" error from black during linting
-click==8.0.1
 docrep>=0.3.1
 # pin jinja2 to fix "module 'jinja2.utils' has no attribute 'escape'" error during linting
 jinja2==3.0.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3831,6 +3831,8 @@ def test_matrix_2_eigenvectors() -> np.ndarray:
 @pytest.fixture(scope="session")
 def test_matrix_3() -> np.ndarray:
     """
+    Definition of test_matrix_3.
+
     Parameters
     ----------
 

--- a/tests/test_gpcca.py
+++ b/tests/test_gpcca.py
@@ -75,6 +75,8 @@ def _assert_schur(
 
 def _find_permutation(expected: np.ndarray, actual: np.ndarray) -> np.ndarray:
     """
+    Find a permutation of a matrix.
+
     Parameters
     ----------
     expected


### PR DESCRIPTION
Pin click to fix 'ImportError: cannot import name '_unicodefun' from 'click'' error from black during linting.