### PR TITLE
Fix failing of no-commit-to-branch by setting 'args: [--branch, main]'.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
     hooks:
     -   id: detect-private-key
     -   id: no-commit-to-branch
+        args: [--branch, main]
     -   id: check-merge-conflict
     -   id: check-ast
     -   id: check-symlinks


### PR DESCRIPTION
Failing of the `no-commit-to-branch` pre-commit hook was due to the fact that `master` is the default branch `no-commit-to-branch` checks for. Since our main branch is named `main` instead of `master`, I had to add `args: [--branch, main]` to .pre-commit-config.yaml:
```
-   id: no-commit-to-branch
        args: [--branch, main]
```
The actual strange thing is that `no-commit-to-branch` didn't complain in the past. Mb. this results from the fact that I just recently (before the last PR #40) activated protection of the `main` branch on GitHub.