### PR TITLE
Fix Operation in Wrong Order error for Krylov approximation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
                     use_slepc: false
         env:
             # make sure to pin this in tox.ini as well
-            PC_VERSION: 3.15.4  # PETSc version
-            SC_VERSION: 3.15.2  # SLEPc version
+            PC_VERSION: 3.18  # PETSc version
+            SC_VERSION: 3.18  # SLEPc version
 
         steps:
         -   uses: actions/checkout@v2

--- a/pygpcca/__init__.py
+++ b/pygpcca/__init__.py
@@ -2,5 +2,5 @@ from pygpcca.utils import stationary_distribution  # type: ignore[attr-defined]
 from pygpcca._gpcca import GPCCA, gpcca_coarsegrain
 
 __author__ = __maintainer__ = "Bernhard Reuter"
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 __email__ = "bernhard-reuter@gmx.de"

--- a/pygpcca/__init__.py
+++ b/pygpcca/__init__.py
@@ -2,5 +2,5 @@ from pygpcca.utils import stationary_distribution  # type: ignore[attr-defined]
 from pygpcca._gpcca import GPCCA, gpcca_coarsegrain
 
 __author__ = __maintainer__ = "Bernhard Reuter"
-__version__ = "1.0.4"
+__version__ = "1.0.3"
 __email__ = "bernhard-reuter@gmx.de"

--- a/pygpcca/_sorted_schur.py
+++ b/pygpcca/_sorted_schur.py
@@ -266,9 +266,10 @@ def sorted_krylov_schur(
     except AttributeError:
         pass
     # Get the schur form
-    R = E.getDS().getMat(SLEPc.DS.MatType.A)
-    R.view()
+    ds = E.getDS()
+    R = ds.getMat(SLEPc.DS.MatType.A)
     R = R.getDenseArray().astype(np.float64)
+    ds.restoreMat(SLEPc.DS.MatType.A,A)
 
     # Gets the number of converged eigenpairs.
     nconv = E.getConverged()

--- a/pygpcca/_sorted_schur.py
+++ b/pygpcca/_sorted_schur.py
@@ -267,8 +267,8 @@ def sorted_krylov_schur(
         pass
     # Get the schur form
     ds = E.getDS()
-    R = ds.getMat(SLEPc.DS.MatType.A)
-    R = R.getDenseArray().astype(np.float64)
+    A = ds.getMat(SLEPc.DS.MatType.A)
+    R = A.getDenseArray().astype(np.float64)
     ds.restoreMat(SLEPc.DS.MatType.A,A)
 
     # Gets the number of converged eigenpairs.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ try:
     from pygpcca import __email__, __author__, __version__, __maintainer__
 except ImportError:
     __author__ = __maintainer__ = "Bernhard Reuter"
-    __version__ = "1.0.3"
+    __version__ = "1.0.4"
     __email__ = "bernhard-reuter@gmx.de"
 
 setup(
@@ -36,10 +36,10 @@ setup(
         # https://gitlab.com/petsc/petsc/-/issues/803
         slepc=[
             "mpi4py>=3.0.3",
-            "petsc>=3.13,!=3.14",
-            "slepc>=3.13,!=3.14",
-            "petsc4py>=3.13,!=3.14",
-            "slepc4py>=3.13,!=3.14",
+            "petsc>=3.18",
+            "slepc>=3.18",
+            "petsc4py>=3.18",
+            "slepc4py>=3.18",
         ],
         dev=["pre-commit>=2.9.0", "bump2version"],
         test=["tox>=3.20.1"],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ try:
     from pygpcca import __email__, __author__, __version__, __maintainer__
 except ImportError:
     __author__ = __maintainer__ = "Bernhard Reuter"
-    __version__ = "1.0.4"
+    __version__ = "1.0.3"
     __email__ = "bernhard-reuter@gmx.de"
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -110,10 +110,10 @@ deps =
     pytest-mock
     # we manually install PETSc and SLEPc on the CI from source and the [dev] installation causes problems
     slepc: mpi4py>=3.0.3
-    slepc: petsc==3.15.4
-    slepc: petsc4py==3.15.1
-    slepc: slepc==3.15.2
-    slepc: slepc4py==3.15.1
+    slepc: petsc==3.18
+    slepc: petsc4py==3.18
+    slepc: slepc==3.18
+    slepc: slepc4py==3.18
 passenv = TOXENV CI CODECOV_* GITHUB_ACTIONS PETSC_* SLEPC_*
 usedevelop = true
 commands = python -m pytest --cov --cov-append --cov-report=term-missing --cov-config={toxinidir}/tox.ini --ignore docs/ {posargs:-vv}


### PR DESCRIPTION
It seems there's an incompatibility with the current version of SLEPC when using a Krylov approximation for getting the sorted schur decomposition.

See recommendation from the SLEPC devs here:
https://gitlab.com/slepc/slepc4py/-/issues/41

Fixing this function removes the error message.