### PR TITLE
Fix issue with no-commit-to-branch during pre-commit hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
     hooks:
     -   id: detect-private-key
     -   id: no-commit-to-branch
+        args: [--branch, main]
     -   id: check-merge-conflict
     -   id: check-ast
     -   id: check-symlinks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
     -   id: detect-private-key
     -   id: no-commit-to-branch
         args: [--branch, main]
+        always_run: false
     -   id: check-merge-conflict
     -   id: check-ast
     -   id: check-symlinks


### PR DESCRIPTION
`no-commit-to-branch` from `pre-commit` hook keeps failing during running the automatic tests when merging a PR into `main`.