### PR TITLE
Remove no-commit-to-branch from pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,10 +36,6 @@ repos:
     rev: v4.3.0
     hooks:
     -   id: detect-private-key
-    -   id: no-commit-to-branch
-        args: [--branch, main]
-        always_run: false
-        stages: [commit]
     -   id: check-merge-conflict
     -   id: check-ast
     -   id: check-symlinks


### PR DESCRIPTION
since we couldn't get it to pass (or not run) after merging a PR into main. 