### PR TITLE
Modernize pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,22 +2,22 @@ fail_fast: false
 default_language_version:
     python: python3
 default_stages:
--   commit
--   push
+-   pre-commit
+-   pre-push
 minimum_pre_commit_version: 3.0.0
 repos:
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.19.1
     hooks:
     -   id: mypy
         additional_dependencies: [numpy>=1.20.0, scipy>=1.6.0]
 -   repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.1.0
     hooks:
     -   id: black
         additional_dependencies: [toml]
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.13.2
+    rev: 7.0.0
     hooks:
     -   id: isort
         additional_dependencies: [toml]
@@ -26,22 +26,20 @@ repos:
     rev: v1.5.0
     hooks:
     -   id: yesqa
-        additional_dependencies: [flake8-tidy-imports, flake8-docstrings, flake8-rst-docstrings, flake8-comprehensions, flake8-bugbear, flake8-logging-format, flake8-blind-except, flake8-builtins, flake8-pytest-style, flake8-string-format]
+        additional_dependencies: [flake8-tidy-imports, flake8-docstrings, flake8-rst-docstrings, flake8-comprehensions, flake8-bugbear, flake8-logging, flake8-blind-except, flake8-builtins, flake8-pytest-style, flake8-string-format]
 -   repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.14.0
+    rev: v2.16.0
     hooks:
     -   id: pretty-format-yaml
         args: [--autofix, --indent, '4', --preserve-quotes]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: detect-private-key
     -   id: check-merge-conflict
     -   id: check-ast
     -   id: check-symlinks
     -   id: check-executables-have-shebangs
-    -   id: fix-encoding-pragma
-        args: [--remove]
     -   id: end-of-file-fixer
     -   id: mixed-line-ending
         args: [--fix=lf]
@@ -55,10 +53,10 @@ repos:
     -   id: check-toml
     -   id: requirements-txt-fixer
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
     -   id: flake8
-        additional_dependencies: [flake8-tidy-imports, flake8-docstrings, flake8-rst-docstrings, flake8-comprehensions, flake8-bugbear, flake8-logging-format, flake8-blind-except, flake8-builtins, flake8-pytest-style, flake8-string-format]
+        additional_dependencies: [flake8-tidy-imports, flake8-docstrings, flake8-rst-docstrings, flake8-comprehensions, flake8-bugbear, flake8-logging, flake8-blind-except, flake8-builtins, flake8-pytest-style, flake8-string-format]
 -   repo: https://github.com/myint/autoflake
     rev: v2.3.1
     hooks:
@@ -71,12 +69,12 @@ repos:
         name: Check executable files use .sh extension
         types: [shell, executable]
 -   repo: https://github.com/asottile/blacken-docs
-    rev: 1.19.1
+    rev: 1.20.0
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==23.1.0]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args: [--py3-plus, --py37-plus]
@@ -90,6 +88,6 @@ repos:
     -   id: rst-directive-colons
     -   id: rst-inline-touching-normal
 -   repo: https://github.com/PyCQA/doc8
-    rev: v1.1.2
+    rev: v2.0.0
     hooks:
     -   id: doc8

--- a/pygpcca/_sort_real_schur.py
+++ b/pygpcca/_sort_real_schur.py
@@ -42,7 +42,7 @@ def sort_real_schur(
     Q: ArrayLike, R: ArrayLike, z: Literal["LM", "LR"], b: float, inplace: bool = False
 ) -> Tuple[ArrayLike, ArrayLike, List[float]]:
     r"""
-    Partially or completely sort the real Schur form `R` and  Schur vectors `Q` of a square matrix `A`.
+    Sort the real Schur form `R` and Schur vectors `Q` of a square matrix `A`, partially or completely.
 
     The diagonal blocks of `R` will be ordered with respect to a target `z`.
 
@@ -82,7 +82,7 @@ def sort_real_schur(
         - R : quasi-triangular real `(n, n)` Schur matrix `R` such that :math:`AQ = QR`
           with the diagonal blocks ordered with respect to the target `z`.
         - ap : A list `ap` warns for inaccuracy of the solution, if an entry of `ap` exceeds one.
-    """  # noqa: D401
+    """
     eps = np.finfo(R.dtype).eps
     if not np.all(np.abs(np.tril(R, -2)) <= 100 * eps):
         raise ValueError("R is not block-triangular.")
@@ -320,7 +320,7 @@ def swaplist(p: Union[ArrayLike, List[float]], s: List[int], z: Literal["LM", "L
     k = 0
     v: List[int] = []
     srtd = 0  # Number of sorted eigenvalues.
-    q = list(np.diff(s))  # Compute block sizes.
+    q = list(map(int, np.diff(s)))  # Compute block sizes.
     q_orig = list(q)  # debug
     fini = False
     while not fini:


### PR DESCRIPTION
- Update all hooks to latest versions (pre-commit autoupdate)
- Replace flake8-logging-format with flake8-logging (the former depends on pkg_resources, removed in setuptools 78+)
- Fix mypy errors in _sort_real_schur.py: cast np.diff output to native int
- Fix D401 docstring in sort_real_schur (imperative mood)
- Update deprecated stage names: commit -> pre-commit, push -> pre-push
- Remove fix-encoding-pragma hook (removed in pre-commit-hooks v6, handled by pyupgrade)
- Remove unnecessary # noqa: D401 (yesqa)